### PR TITLE
Remove duplicate wallet-adapter dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,8 @@
   "dependencies": {
     "@heroicons/react": "^1.0.5",
     "@solana/wallet-adapter-base": "^0.9.2",
-    "@solana/wallet-adapter-phantom": "^0.9.2",
     "@solana/wallet-adapter-react": "^0.15.2",
     "@solana/wallet-adapter-react-ui": "^0.9.4",
-    "@solana/wallet-adapter-solflare": "^0.6.2",
-    "@solana/wallet-adapter-sollet": "^0.10.3",
     "@solana/wallet-adapter-wallets": "^0.14.2",
     "@solana/web3.js": "^1.31.0",
     "@tailwindcss/typography": "^0.5.0",


### PR DESCRIPTION
`@solana/wallet-adapter-wallets` includes all the individual wallet adapters as dependencies, so you can import from that.

These are already being imported this way @ https://github.com/lisenmayben/solana-dapp-next/blob/c7e0f870524a12c6bcbb38912a2382546374d0e4/src/contexts/ContextProvider.tsx#L12

I do recommend uncommenting and including Torus, since it's useful to have a loadable wallet option that doesn't require an installation or seed phrase, and Torus is used as a default for this in the react-ui package.